### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 jupyter
 openai
-dotenv
+python-dotenv


### PR DESCRIPTION
Dear Authors,

“dotenv” is not a valid package name. Please use the following correct package name in requirements.txt instead:
```
python-dotenv
```